### PR TITLE
fix ipython new version fail to compile

### DIFF
--- a/caliopen/cli/commands/setup_storage.py
+++ b/caliopen/cli/commands/setup_storage.py
@@ -13,12 +13,12 @@ def setup_storage(settings=None):
     from caliopen.base.user.core import User
     from caliopen.base.message.core.thread import Thread
     from caliopen.base.message.core.message import Message
-    from cqlengine.management import sync_table, create_keyspace
+    from cassandra.cqlengine.management import sync_table, create_keyspace_simple
     keyspace = Configuration('global').get('cassandra.keyspace')
     if not keyspace:
         raise Exception('Configuration missing for cassandra keyspace')
     # XXX tofix : define strategy and replication_factor in configuration
-    create_keyspace(keyspace, 'SimpleStrategy', 1)
+    create_keyspace_simple(keyspace, 'SimpleStrategy', 1)
     for name, kls in core_registry.items():
         log.info('Creating cassandra model %s' % name)
         sync_table(kls._model_class)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 requires = [
     'caliopen.base',
     'caliopen.base.user',
-    'ipython',
+    'ipython==4.0.0',
 ]
 
 setup(name='caliopen.cli',


### PR DESCRIPTION
ipython 4.0.1 is installed automatically. But this version fail on OSX
```
error: Setup script exited with error in ipython setup command: Invalid
environment marker: sys_platform == "darwin" and
platform_python_implementation == "CPython"
```
Version 4.0.0 compile without problems