### PR TITLE
fix setup command: AttributeError "no attribute 'export_for_schema'"

### DIFF
--- a/caliopen/cli/commands/setup_storage.py
+++ b/caliopen/cli/commands/setup_storage.py
@@ -18,7 +18,7 @@ def setup_storage(settings=None):
     if not keyspace:
         raise Exception('Configuration missing for cassandra keyspace')
     # XXX tofix : define strategy and replication_factor in configuration
-    create_keyspace_simple(keyspace, 'SimpleStrategy', 1)
+    create_keyspace_simple(keyspace, 1)
     for name, kls in core_registry.items():
         log.info('Creating cassandra model %s' % name)
         sync_table(kls._model_class)


### PR DESCRIPTION
moving to create_keyspace_simple, it does not require classname anymore
cf.
https://github.com/datastax/python-driver/blob/3.0.0/cassandra/cqlengine/management.py#L40