### PR TITLE
[chore] configure dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# This file creates a container that runs a {package} caliopen API
+# Important:
+# Author: Caliopen
+# Date: 2015-01-12
+
+FROM debian:jessie
+MAINTAINER Caliopen
+ENV DEBIAN_FRONTEND noninteractive
+
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+RUN apt-get install -y python python-dev python-pip git libffi-dev
+# use a decent version
+RUN pip install -U pip
+
+# Version installed in Debian do not work !#@!@#!@#
+RUN apt-get remove -y python-cffi
+
+
+ADD . /srv/caliopen/cli
+WORKDIR /srv/caliopen/cli/
+
+# Install the source in the /srv/caliopen/api
+RUN pip install bcrypt
+RUN pip install git+https://github.com/CaliOpen/caliopen.base.git
+RUN pip install git+https://github.com/CaliOpen/caliopen.base.user.git
+RUN pip install git+https://github.com/CaliOpen/caliopen.base.message.git
+RUN pip install git+https://github.com/CaliOpen/caliopen.messaging.git
+RUN pip install git+https://github.com/CaliOpen/caliopen.smtp.git
+RUN python setup.py develop
+
+RUN useradd docker
+
+RUN cp /srv/caliopen/cli/docker/entrypoint.sh /docker-entrypoint.sh
+RUN chmod 750  /docker-entrypoint.sh
+RUN chown docker /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "$@"  # start the real command: see command in docker-compose.yml or Dockerfile

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 requires = [
     'caliopen.base',
     'caliopen.base.user',
+    'caliopen.base.message',
+    'caliopen.smtp',
     'ipython==4.0.0',
 ]
 


### PR DESCRIPTION
+ add missing dependencies caliopen.base.message & caliopen.smtp

The PR #6 should be merged before this one

---

Then we will able to do:

~~~
docker-compose run cli caliopen -f /usr/share/caliopen/base/caliopen.yaml.template setup
docker-compose run cli caliopen -f /usr/share/caliopen/base/caliopen.yaml.template create_user -e julien.muetton@gandi.net -g Julien -f Muetton -p 123456
docker-compose run cli caliopen -f /usr/share/caliopen/base/caliopen.yaml.template import -e julien.muetton@gandi.net -f mbox -p "/usr/share/caliopen/bin/fixtures/julien.muetton@gandi.net/mbox/"
~~~