### PR TITLE
Install caliopen packages as editable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ MAINTAINER Caliopen
 ENV DEBIAN_FRONTEND noninteractive
 
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y locales
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
+RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y python python-dev python-pip git libffi-dev
 # use a decent version
@@ -21,15 +19,17 @@ RUN apt-get remove -y python-cffi
 
 
 ADD . /srv/caliopen/cli
-WORKDIR /srv/caliopen/cli/
+WORKDIR /srv/caliopen/
 
 # Install the source in the /srv/caliopen/api
 RUN pip install bcrypt
-RUN pip install git+https://github.com/CaliOpen/caliopen.base.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.base.user.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.base.message.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.messaging.git
-RUN pip install git+https://github.com/CaliOpen/caliopen.smtp.git
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.base.git#egg=caliopen.base
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.base.user.git#egg=caliopen.base.user
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.base.message.git#egg=caliopen.base.message
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.messaging.git#egg=caliopen.messaging
+RUN pip install -e git+https://github.com/CaliOpen/caliopen.smtp.git#egg=caliopen.smtp
+
+WORKDIR /srv/caliopen/cli/
 RUN python setup.py develop
 
 RUN useradd docker


### PR DESCRIPTION
This allows caliopen-dev to start in full dev mode

+ remove locales configuration that are not required anymore in docker build

cf. CaliOpen/Caliopen#15